### PR TITLE
Only add the snippet to HTML responses

### DIFF
--- a/src/EventSubscriber/GoogleTagResponseSubscriber.php
+++ b/src/EventSubscriber/GoogleTagResponseSubscriber.php
@@ -12,6 +12,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Path\AliasManagerInterface;
 use Drupal\Core\Path\CurrentPathStack;
 use Drupal\Core\Path\PathMatcherInterface;
+use Drupal\Core\Render\HtmlResponse;
 use Drupal\Core\Session\AccountProxyInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -186,6 +187,10 @@ EOS;
       return FALSE;
     }
 
+    if (!($response instanceof HtmlResponse)) {
+      // Omit snippet because the response is not HTML.
+      return FALSE;
+    }
 
     return TRUE;
   }


### PR DESCRIPTION
I am working on a Drupal 8 application and received this error while trying to view an image uploaded to Drupal's private files directory:

`LogicException: The content cannot be set on a BinaryFileResponse instance. in Symfony\Component\HttpFoundation\BinaryFileResponse->setContent() (line 286 of core/vendor/symfony/http-foundation/BinaryFileResponse.php).`

I tracked the error down to the `google_tag` module. It attempts to add the Google Tag Manager tag to responses that are not HTML, like the `BinaryFileResponse` used by the private files system to serve up images.

This PR includes a check to only add the tag if `$response` is an instance of `HtmlResponse`.
