### PR TITLE
Fix for deprecated non-escaped \ on yaml files

### DIFF
--- a/google_tag.routing.yml
+++ b/google_tag.routing.yml
@@ -2,6 +2,6 @@ google_tag.settings_form:
   path: "/admin/config/system/google_tag"
   defaults:
     _title: "Google Tag Manager"
-    _form: "\Drupal\google_tag\Form\GoogleTagSettingsForm"
+    _form: "\\Drupal\\google_tag\\Form\\GoogleTagSettingsForm"
   requirements:
     _permission: 'administer google tag manager'

--- a/google_tag.routing.yml
+++ b/google_tag.routing.yml
@@ -1,7 +1,7 @@
 google_tag.settings_form:
-  path: "/admin/config/system/google_tag"
+  path: '/admin/config/system/google_tag'
   defaults:
-    _title: "Google Tag Manager"
-    _form: "\\Drupal\\google_tag\\Form\\GoogleTagSettingsForm"
+    _title: 'Google Tag Manager'
+    _form: '\Drupal\google_tag\Form\GoogleTagSettingsForm'
   requirements:
     _permission: 'administer google tag manager'


### PR DESCRIPTION
With Symfony 2.8 we have a deprecated way to call the form class in the routing.yml file:

http://symfony.com/blog/new-in-symfony-2-8-yaml-deprecations
